### PR TITLE
KeyError on missing response data

### DIFF
--- a/pyscape/util/output.py
+++ b/pyscape/util/output.py
@@ -32,7 +32,10 @@ def to_csv(outfile, ph, preset, data):
     for record in data:
         line = []
         for k in keys:
-            line.append(record[k])
+            if k in record:
+                line.append(record[k])
+            else:
+                line.append('')
         output.append(line)
 
     try:


### PR DESCRIPTION
Some keys don't exist in the Moz response data (depending on account type), added logic to prevent key errors when generating CSV output.